### PR TITLE
prefer single quotes unless it requires escaping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,6 +73,10 @@ rules:
   padded-blocks:
   - error
   - never
+  quotes:
+  - error
+  - single
+  - avoidEscape: true
   semi:
   - error
   - always


### PR DESCRIPTION
This is a reasonable rule that is not currently being enforced, but should be. cc @sarahyablok
